### PR TITLE
Rav3nPL's Open CL Compile Fix

### DIFF
--- a/calc_addrs.cl
+++ b/calc_addrs.cl
@@ -177,7 +177,7 @@ typedef struct {
 } bignum;
 
 __constant bn_word modulus[] = { MODULUS_BYTES };
-__constant bignum bn_zero = {};
+__constant bignum bn_zero = {{0x0}};
 
 __constant bn_word mont_rr[BN_NWORDS] = { 0xe90a1, 0x7a2, 0x1, 0, };
 __constant bn_word mont_n0[2] = { 0xd2253531, 0xd838091d };


### PR DESCRIPTION
Fix for:

Compiling kernel, can take minutes...failure.
clBuildProgram: CL_BUILD_PROGRAM_FAILURE
Build log:
"C:\Users\vg\AppData\Local\Temp\OCL1972T1.cl", line 173: error: expected an
          expression
  __constant bignum bn_zero = {};
                               ^

Changed to:
__constant bignum bn_zero = {{0x0}};